### PR TITLE
Remove logger dependency, add convenience initializer

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,5 @@ let package = Package(
     dependencies: [
         .Package(url: "https://github.com/Zewo/String.git", majorVersion: 0, minor: 7),
         .Package(url: "https://github.com/Zewo/URI.git", majorVersion: 0, minor: 8),
-        .Package(url: "https://github.com/Zewo/Log.git", majorVersion: 0, minor: 8)
     ]
 )

--- a/Sources/SQL/Core/ConnectionProtocol.swift
+++ b/Sources/SQL/Core/ConnectionProtocol.swift
@@ -36,24 +36,7 @@ public protocol ConnectionInfoProtocol {
     var username: String? { get }
     var password: String? { get }
     
-    init(host: String, port: Int, databaseName: String, username: String?, password: String?)
     init?(uri: URI)
-}
-
-public extension ConnectionInfoProtocol {
-    public init?(uri: URI) {
-        guard let host = uri.host, port = uri.port, databaseName = uri.path?.trim(["/"]) else {
-            return nil
-        }
-
-        self.init(
-            host: host,
-            port: port,
-            databaseName: databaseName,
-            username: uri.userInfo?.username,
-            password: uri.userInfo?.password
-        )
-    }
 }
 
 public protocol ConnectionProtocol: class {

--- a/Sources/SQL/Core/ConnectionProtocol.swift
+++ b/Sources/SQL/Core/ConnectionProtocol.swift
@@ -23,7 +23,6 @@
 // SOFTWARE.
 
 @_exported import URI
-@_exported import Log
 
 
 /**
@@ -37,9 +36,25 @@ public protocol ConnectionInfoProtocol {
     var username: String? { get }
     var password: String? { get }
     
-    init(_ uri: URI) throws
+    init(host: String, port: Int, databaseName: String, username: String?, password: String?)
+    init?(uri: URI)
 }
 
+public extension ConnectionInfoProtocol {
+    public init?(uri: URI) {
+        guard let host = uri.host, port = uri.port, databaseName = uri.path?.trim(["/"]) else {
+            return nil
+        }
+
+        self.init(
+            host: host,
+            port: port,
+            databaseName: databaseName,
+            username: uri.userInfo?.username,
+            password: uri.userInfo?.password
+        )
+    }
+}
 
 public protocol ConnectionProtocol: class {
     associatedtype InternalStatus
@@ -47,8 +62,6 @@ public protocol ConnectionProtocol: class {
     associatedtype Error: ErrorProtocol, CustomStringConvertible
     associatedtype ConnectionInfo: ConnectionInfoProtocol
     associatedtype QueryRenderer: QueryRendererProtocol
-    
-    var logger: Logger? { get set }
     
     var connectionInfo: ConnectionInfo { get }
 
@@ -72,15 +85,18 @@ public protocol ConnectionProtocol: class {
 
     func rollbackToSavePointNamed(_ name: String) throws
 
-    init(_ info: ConnectionInfo)
+    init(info: ConnectionInfo)
     
     var mostRecentError: Error? { get }
 }
 
 public extension ConnectionProtocol {
     
-    public init(_ uri: URI) throws {
-        try self.init(ConnectionInfo(uri))
+    public init?(uri: URI) {
+        guard let info = ConnectionInfo(uri: uri) else {
+            return nil
+        }
+        self.init(info: info)
     }
 
     public func transaction<T>(handler: (Void) throws -> T) throws -> T {


### PR DESCRIPTION
Adds back the labels, `throws` -> `?`, make it required to have a non-uri initializer.

Also removes the logger dependency - lmk if I should add that back. Doesn't make much sense to me for it to be in the protocol though (but maybe I'm missing something).
