### PR TITLE
Fix == (lhs: Entity, rhs: Entity) -> Bool

### DIFF
--- a/Sources/SQL/Model/Entity.swift
+++ b/Sources/SQL/Model/Entity.swift
@@ -141,5 +141,5 @@ public struct PersistedEntity<Model: ModelProtocol> : PersistedEntityProtocol wh
 }
 
 public func == <Model: ModelProtocol, Entity: PersistedEntityProtocol> (lhs: Entity, rhs: Entity) -> Bool where Entity.Model == Model {
-    return "\(Model.Field.tableName).\(lhs.primaryKey.hashValue)" == "\(Model.Field.tableName).\(rhs.primaryKey.hashValue)"
+    return lhs.primaryKey == rhs.primaryKey
 }

--- a/Sources/SQL/Model/Entity.swift
+++ b/Sources/SQL/Model/Entity.swift
@@ -140,6 +140,6 @@ public struct PersistedEntity<Model: ModelProtocol> : PersistedEntityProtocol wh
     }
 }
 
-public func == <Model: ModelProtocol, Entity: PersistedEntityProtocol> (lhs: Entity, rhs: Entity) -> Bool where Entity.Model == Model {
+public func == <Entity: PersistedEntityProtocol> (lhs: Entity, rhs: Entity) -> Bool {
     return lhs.primaryKey == rhs.primaryKey
 }


### PR DESCRIPTION
Equality of the hash values does not guarantee the equality of the bases.
